### PR TITLE
feat: allow passing args to object methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,12 @@
     }
     for (var idx = 0; idx < path.length; idx += 1) {
       var key = path[idx];
-      obj = typeof obj[key] === 'function' ? obj[key]() : obj[key];
+      var call = key.split(' ');
+      var fn = call[0];
+      var args = call.slice(1);
+      obj = typeof obj[fn] === 'function'
+      	? obj[fn].apply(null, args)
+        : obj[key];
     }
     return obj;
   };


### PR DESCRIPTION
Add the ability to pass (string) arguments to object methods in a space delimited format. From what I understand, this would preclude strict adherence to Python's string formatting where spaces would be valid in keys when resolving against the object.

#### Examples

Assume all examples below use this object:
```javascript
var obj = {
  getFirstName (other) {
    if (other) return 'Billy'
    return 'Alec'
  },
  lastName: 'Baldwin'
}
```

Prior to this PR, simple object method calls could be made:

```javascript
'{getFirstName} {lastName} did the thing.'.format(obj)
// -> 'Alec Baldwin did the thing.'
```

The above will continue to work the same way, but this PR additionally allows for passing arguments to these functions:

```javascript
'{getFirstName true} {lastName} did the thing.'.format(obj)

// -> 'Billy Baldwin did the thing.'
```

Note, however, that even though I'm passing `true` the arguments passed are always strings. The function's `if` only checks for a truthy value in this simple case but if you were expecting anything else you'd have to cast it yourself ( eg. using `Boolean` or `Number` constructors, or `parseInt()` ).

Given this is a _string_ formatting library, this limitation doesn't seem like much of a limitation.