### PR TITLE
feat(methods): improve method invocation

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,13 +75,24 @@
       let key = path[idx]
       let keyArray = key.split(' ')
       let fn = keyArray[0]
-      let args = keyArray.slice(1)
       obj = typeof obj[fn] === 'function'
-        ? obj[fn].apply(obj, args)
+        ? obj[fn].apply(obj, parseMethodArgs(keyArray))
         : obj[key]
     }
 
     return obj
+  }
+  
+  function parseMethodArgs (keyArray) {
+  	return keyArray
+    	.slice(1)
+      .join(' ')
+      .split(/,\s*/g)
+      .map(v => {
+        if (v === '_') return null
+        if (v === '__') return '_'
+        return v
+      })
   }
 
   let format = create({})

--- a/index.js
+++ b/index.js
@@ -82,10 +82,10 @@
 
     return obj
   }
-  
+
   function parseMethodArgs (keyArray) {
-  	return keyArray
-    	.slice(1)
+    return keyArray
+      .slice(1)
       .join(' ')
       .split(/,\s*/g)
       .map(v => {

--- a/tests/function-mode.js
+++ b/tests/function-mode.js
@@ -111,13 +111,6 @@ test('allows property shorthand for the first positional argument', t => {
   t.is(result, expected)
 })
 
-test('invokes methods', t => {
-  t.is(format('{0.toLowerCase}', ['TINY BOOM']), 'tiny boom')
-  t.is(format('{0.toUpperCase}', ['huge boom']), 'HUGE BOOM')
-  t.is(format('{0.getFullYear}', [new Date('13 Sep 1994')]), '1994')
-  t.is(format('{pop} {pop} {pop}', [['one', 'two', 'three']]), 'three two one')
-})
-
 test(`maintains basic semantic compatibility with Python's API`, t => {
   t.is(format('', ''), '')
   t.is(format('abc', ''), 'abc')

--- a/tests/method-invocation.js
+++ b/tests/method-invocation.js
@@ -1,0 +1,51 @@
+import format from '../index'
+import test from 'ava'
+
+let obj = {
+  addFive: value => Number(value) + 5
+  xform (str, upper, reverse) {
+    let output = str + ' ' + str
+    if (upper) output = output.toUpperCase()
+    if (reverse) output = output.split('').reverse().join('')
+    return output
+  },
+  countNulls (one, two, three, four, five, six) {
+    return Array
+      .from(arguments)
+      .filter(v => v === null)
+      .length
+  }
+}
+
+test('invokes methods taking no arguments', t => {
+  t.is(format('{0.toLowerCase}', ['TINY BOOM']), 'tiny boom')
+  t.is(format('{0.toUpperCase}', ['huge boom']), 'HUGE BOOM')
+  t.is(format('{0.getFullYear}', [new Date('13 Sep 1994')]), '1994')
+  t.is(format('{pop} {pop} {pop}', [['one', 'two', 'three']]), 'three two one')
+})
+
+test('invokes methods and passes a single argument', t => {
+  t.is(format('{addFive 1}', obj), '6')
+  t.is(format('{addFive 2}', obj), '7')
+  t.is(format('{addFive 3}', obj), '8')
+})
+
+test('invokes methods and passes multiple arguments', t => {
+  t.is(format('{xform hi, true}', obj), 'HI HI')
+  t.is(format('{xform hi, _, true}', obj), 'ih ih')
+  t.is(format('{xform hi, true, true}', obj), 'IH IH')
+})
+
+test('allows passing `_` to nullify an argument', t => {
+  t.is(format('{countNulls 1, 2, 3, 4, 5, 6}', obj), '0')
+  t.is(format('{countNulls 1, 2, 3, _, 5, 6}', obj), '1')
+  t.is(format('{countNulls _, 2, 3, _, 5, 6}', obj), '2')
+  t.is(format('{countNulls 1, _, 3, _, _, 6}', obj), '3')
+  t.is(format('{countNulls _, _, 3, _, 5, _}', obj), '4')
+  t.is(format('{countNulls _, _, _, 4, _, _}', obj), '5')
+  t.is(format('{countNulls _, _, _, _, _, _}', obj), '6')
+})
+
+test('treats `__` as an escaped `_`', t => {
+  t.is(format('{xform __}', obj), '_')
+})

--- a/tests/method-invocation.js
+++ b/tests/method-invocation.js
@@ -2,7 +2,7 @@ import format from '../index'
 import test from 'ava'
 
 let obj = {
-  addFive: value => Number(value) + 5
+  addFive: value => Number(value) + 5,
   xform (str, upper, reverse) {
     let output = str + ' ' + str
     if (upper) output = output.toUpperCase()

--- a/tests/method-invocation.js
+++ b/tests/method-invocation.js
@@ -2,6 +2,7 @@ import format from '../index'
 import test from 'ava'
 
 let obj = {
+  echo: value => value,
   addFive: value => Number(value) + 5,
   xform (str, upper, reverse) {
     let output = str + ' ' + str
@@ -47,5 +48,5 @@ test('allows passing `_` to nullify an argument', t => {
 })
 
 test('treats `__` as an escaped `_`', t => {
-  t.is(format('{xform __}', obj), '_')
+  t.is(format('{echo __}', obj), '_')
 })


### PR DESCRIPTION
Before:

```javascript
let object = {
  react (tired, mood) {
    if (tired) return 'no energy'
    return mood
  }
}

// ... how are we supposed to make `tired` falsy?
format('{react false mad}', object)
// -> 'no energy'
// `false` is passed as a string, which is truthy

// note the extra space
format('{react  mad}', object)
// -> 'mad'
// ... ew
```

After:

```javascript
let object = {
  react (tired, mood) {
    if (tired) return 'no energy'
    return mood
  }
}

format('{react true, mad}', object)
// -> 'no energy'
format('{react _, mad}', object)
// -> 'mad'
```

Arguments are still always passed as strings, but now the `_` character as an argument passes false which makes it _actually_ falsy. Prior to this, the only real way to pass a falsy value was to make it an extra space. That's all of ugly, unreliable, easy to miss, and hard to reason about.

The `_` concept aligns with several programming languages, at least including F# and I think Elixir where using it as a parameter name essentially means you don't care about that parameter.

This also allows for passing arguments containing spaces, such as `{react _, super ultra mad}`. That would result in two arguments, `null` and `'super ultra mad'`.

In case you want to actually pass a lone underscore as an argument, use `__` ( escape it with another underscore ).